### PR TITLE
Logic #143 without Requirement Change or damage boost past the mini thwomps

### DIFF
--- a/worlds/ladx/LADXR/logic/dungeon6.py
+++ b/worlds/ladx/LADXR/logic/dungeon6.py
@@ -6,7 +6,7 @@ from ..locations.all import *
 class Dungeon6:
     def __init__(self, options, world_setup, r, *, raft_game_chest=True):
         entrance = Location(dungeon=6)
-        Location(dungeon=6).add(DungeonChest(0x1CF)).connect(entrance, OR(BOMB, BOW, MAGIC_ROD, COUNT(POWER_BRACELET, 2))) # 50 rupees
+        Location(dungeon=6).add(DungeonChest(0x1CF)).connect(entrance, OR(r.attack_wizrobe, COUNT(POWER_BRACELET, 2))) # 50 rupees
         Location(dungeon=6).add(DungeonChest(0x1C9)).connect(entrance, COUNT(POWER_BRACELET, 2)) # 100 rupees start
         if options.owlstatues == "both" or options.owlstatues == "dungeon":
             Location(dungeon=6).add(OwlStatue(0x1BB)).connect(entrance, STONE_BEAK6)
@@ -15,9 +15,9 @@ class Dungeon6:
         bracelet_chest = Location(dungeon=6).add(DungeonChest(0x1CE)).connect(entrance, AND(BOMB, FEATHER))
 
         # left side
-        Location(dungeon=6).add(DungeonChest(0x1C0)).connect(entrance, AND(POWER_BRACELET, OR(BOMB, BOW, MAGIC_ROD))) # 3 wizrobes raised blocks dont need to hit the switch
+        Location(dungeon=6).add(DungeonChest(0x1C0)).connect(entrance, AND(POWER_BRACELET, r.attack_wizrobe)) # 3 wizrobes raised blocks dont need to hit the switch
         left_side = Location(dungeon=6).add(DungeonChest(0x1B9)).add(DungeonChest(0x1B3)).connect(entrance, AND(POWER_BRACELET, OR(BOMB, BOOMERANG)))
-        Location(dungeon=6).add(DroppedKey(0x1B4)).connect(left_side, OR(BOMB, BOW, MAGIC_ROD)) # 2 wizrobe drop key
+        Location(dungeon=6).add(DroppedKey(0x1B4)).connect(left_side, OR(r.attack_wizrobe, BOW)) # 2 wizrobe drop key, allow bow as only 2
         top_left = Location(dungeon=6).add(DungeonChest(0x1B0)).connect(left_side, COUNT(POWER_BRACELET, 2)) # top left chest horseheads
         if raft_game_chest:
             Location().add(Chest(0x06C)).connect(top_left, POWER_BRACELET)  # seashell chest in raft game
@@ -25,18 +25,18 @@ class Dungeon6:
         # right side
         to_miniboss = Location(dungeon=6).connect(entrance, KEY6)
         miniboss = Location(dungeon=6).connect(to_miniboss, AND(BOMB, r.miniboss_requirements[world_setup.miniboss_mapping[5]]))
-        lower_right_side = Location(dungeon=6).add(DungeonChest(0x1BE)).connect(entrance, AND(OR(BOMB, BOW, MAGIC_ROD), COUNT(POWER_BRACELET, 2))) # waterway key
+        lower_right_side = Location(dungeon=6).add(DungeonChest(0x1BE)).connect(entrance, AND(r.attack_wizrobe, COUNT(POWER_BRACELET, 2))) # waterway key
         medicine_chest = Location(dungeon=6).add(DungeonChest(0x1D1)).connect(lower_right_side, FEATHER) # ledge chest medicine
         if options.owlstatues == "both" or options.owlstatues == "dungeon":
             lower_right_owl = Location(dungeon=6).add(OwlStatue(0x1D7)).connect(lower_right_side, AND(POWER_BRACELET, STONE_BEAK6))
 
         center_1 = Location(dungeon=6).add(DroppedKey(0x1C3)).connect(miniboss, AND(COUNT(POWER_BRACELET, 2), FEATHER)) # tile room key drop
-        center_2_and_upper_right_side = Location(dungeon=6).add(DungeonChest(0x1B1)).connect(center_1, AND(KEY6, FOUND(KEY6, 2))) # top right chest horseheads
+        center_2_and_upper_right_side = Location(6).add(DungeonChest(0x1B1)).connect(center_1, AND(COUNT(POWER_BRACELET, 2), PEGASUS_BOOTS, r.attack_pols_voice, AND(KEY6, FOUND(KEY6, 2)))) # top right chest horseheads
         boss_key = Location(dungeon=6).add(DungeonChest(0x1B6)).connect(center_2_and_upper_right_side, AND(AND(KEY6, FOUND(KEY6, 3), HOOKSHOT)))
         if options.owlstatues == "both" or options.owlstatues == "dungeon":
             Location(dungeon=6).add(OwlStatue(0x1B6)).connect(boss_key, STONE_BEAK6)
 
-        boss = Location(dungeon=6).add(HeartContainer(0x1BC), Instrument(0x1b5)).connect(center_1, AND(NIGHTMARE_KEY6, r.boss_requirements[world_setup.boss_mapping[5]]))
+        boss = Location(dungeon=6).add(HeartContainer(0x1BC), Instrument(0x1b5)).connect(center_1, AND(NIGHTMARE_KEY6, OR(r.attack_hookshot, SHIELD), r.boss_requirements[world_setup.boss_mapping[5]]))
 
         if options.logic == 'hard' or options.logic == 'glitched' or options.logic == 'hell':
             bracelet_chest.connect(entrance, BOMB) # get through 2d section by "fake" jumping to the ladders


### PR DESCRIPTION
Based on 143 https://github.com/daid/LADXR/commit/465a16f574afa5a90939e1c603f5e0fc2c1866fb#diff-6e620de86ac090bfced823cb30c8d5bf26ab98ebe65744fcbc8485977a1e0538

 D6: adjust killing wizrobes, and add assumed logic requirements from …

…previous nodes (#143)

* d6 clean up dependencies

* add requirements attack_wizrobe and attack_pols_voice

new attack requirements to clean up d6

* bracket

* requirements logic changes

remove bow from normal logic due to limited capacity from starter ghost not being enough to clear rooms.

Add bow to hard logic in combination with a stun device, so only 4 arrows are needed to clear a room.

* cleanup requirements higher logics

avoid duplicating lines of code and make it easier to read

* clean up comment

Remove superfluous comment


NOT IMPLEMENTED:
* d6 damage boost past mini thwomps
because AP handles KEY code differently than LADX