### PR TITLE
Hotfix/fixed tutorial bug after core update

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -142,7 +142,7 @@ def tutorial_redirect(game: str, file: str, lang: str):
     return redirect(url_for("tutorial", game=game, file=f"{file}_{lang}"), code=301)
 
 
-@app.route('/tutorial/')
+@app.route('/tutorial')
 @cache.cached()
 def tutorial_landing():
     tutorials = {}

--- a/docs/Custom Worlds Docs/PlateUP/docs/en_PlateUp.md
+++ b/docs/Custom Worlds Docs/PlateUP/docs/en_PlateUp.md
@@ -1,0 +1,34 @@
+# PlateUp!
+
+## What is PlateUp!? 
+
+TBA
+
+## Game Progression
+
+TBA
+
+## Key Items
+
+TBA
+
+## Reward Placement
+
+TBA
+
+## Trapped Chests
+
+TBA
+
+
+## Other information
+
+TBA
+
+## Where is the settings page?
+
+TBA
+
+## When does a player receive items?
+
+TBA

--- a/docs/Custom Worlds Docs/PlateUP/docs/setup_en.md
+++ b/docs/Custom Worlds Docs/PlateUP/docs/setup_en.md
@@ -1,0 +1,22 @@
+# PlateUp! Setup Guide
+
+### How to play:
+
+TBA
+
+
+## Hosting a MultiWorld game
+
+The recommended way to host a game is to use our hosting service. The process is relatively simple:
+
+1. Collect config files from your players.
+2. Create a zip file containing your players' config files.
+3. Upload that zip file to the Generate page above.
+    - Generate page: [WebHost Seed Generation Page](/generate)
+4. Wait a moment while the seed is generated.
+5. When the seed is generated, you will be redirected to a "Seed Info" page.
+6. Click "Create New Room". This will take you to the server page. Provide the link to this page to your players, so
+   they may download their patch files from there.
+7. Note that a link to a MultiWorld Tracker is at the top of the room page. The tracker shows the progress of all
+   players in the game. Any observers may also be given the link to this page.
+8. Once all players have joined, you may begin playing.

--- a/docs/Custom Worlds Docs/mindustry/docs/en_Mindustry.md
+++ b/docs/Custom Worlds Docs/mindustry/docs/en_Mindustry.md
@@ -1,0 +1,34 @@
+# Mindustry
+
+## What is Mindustry? 
+
+TBA
+
+## Game Progression
+
+TBA
+
+## Key Items
+
+TBA
+
+## Reward Placement
+
+TBA
+
+## Trapped Chests
+
+TBA
+
+
+## Other information
+
+TBA
+
+## Where is the settings page?
+
+TBA
+
+## When does a player receive items?
+
+TBA

--- a/docs/Custom Worlds Docs/mindustry/docs/setup_en.md
+++ b/docs/Custom Worlds Docs/mindustry/docs/setup_en.md
@@ -1,0 +1,22 @@
+# Mindustry Setup Guide
+
+### How to play:
+
+TBA
+
+
+## Hosting a MultiWorld game
+
+The recommended way to host a game is to use our hosting service. The process is relatively simple:
+
+1. Collect config files from your players.
+2. Create a zip file containing your players' config files.
+3. Upload that zip file to the Generate page above.
+    - Generate page: [WebHost Seed Generation Page](/generate)
+4. Wait a moment while the seed is generated.
+5. When the seed is generated, you will be redirected to a "Seed Info" page.
+6. Click "Create New Room". This will take you to the server page. Provide the link to this page to your players, so
+   they may download their patch files from there.
+7. Note that a link to a MultiWorld Tracker is at the top of the room page. The tracker shows the progress of all
+   players in the game. Any observers may also be given the link to this page.
+8. Once all players have joined, you may begin playing.

--- a/docs/Custom Worlds Docs/pharcryption/docs/en_Pharcryption.md
+++ b/docs/Custom Worlds Docs/pharcryption/docs/en_Pharcryption.md
@@ -1,0 +1,34 @@
+# Pharcryption
+
+## What is Pharcryption? 
+
+TBA
+
+## Game Progression
+
+TBA
+
+## Key Items
+
+TBA
+
+## Reward Placement
+
+TBA
+
+## Trapped Chests
+
+TBA
+
+
+## Other information
+
+TBA
+
+## Where is the settings page?
+
+TBA
+
+## When does a player receive items?
+
+TBA

--- a/docs/Custom Worlds Docs/pharcryption/docs/setup_en.md
+++ b/docs/Custom Worlds Docs/pharcryption/docs/setup_en.md
@@ -1,0 +1,22 @@
+# Pharcryption Setup Guide
+
+### How to play:
+
+TBA
+
+
+## Hosting a MultiWorld game
+
+The recommended way to host a game is to use our hosting service. The process is relatively simple:
+
+1. Collect config files from your players.
+2. Create a zip file containing your players' config files.
+3. Upload that zip file to the Generate page above.
+    - Generate page: [WebHost Seed Generation Page](/generate)
+4. Wait a moment while the seed is generated.
+5. When the seed is generated, you will be redirected to a "Seed Info" page.
+6. Click "Create New Room". This will take you to the server page. Provide the link to this page to your players, so
+   they may download their patch files from there.
+7. Note that a link to a MultiWorld Tracker is at the top of the room page. The tracker shows the progress of all
+   players in the game. Any observers may also be given the link to this page.
+8. Once all players have joined, you may begin playing.

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -224,7 +224,7 @@ class WebWorld(metaclass=WebWorldRegister):
     game_info_languages: List[str] = ['en']
     """docs folder will be scanned for game info pages using this list in the format '{language}_{game_name}.md'"""
 
-    tutorials: List["Tutorial"]
+    tutorials: List["Tutorial"] = {}
     """docs folder will also be scanned for tutorial guides. Each Tutorial class is to be used for one guide."""
 
     theme = "grass"

--- a/worlds/mindustry/docs/en_Mindustry.md
+++ b/worlds/mindustry/docs/en_Mindustry.md
@@ -1,0 +1,34 @@
+# Mindustry
+
+## What is Mindustry? 
+
+TBA
+
+## Game Progression
+
+TBA
+
+## Key Items
+
+TBA
+
+## Reward Placement
+
+TBA
+
+## Trapped Chests
+
+TBA
+
+
+## Other information
+
+TBA
+
+## Where is the settings page?
+
+TBA
+
+## When does a player receive items?
+
+TBA

--- a/worlds/mindustry/docs/setup_en.md
+++ b/worlds/mindustry/docs/setup_en.md
@@ -1,0 +1,22 @@
+# Mindustry Setup Guide
+
+### How to play:
+
+TBA
+
+
+## Hosting a MultiWorld game
+
+The recommended way to host a game is to use our hosting service. The process is relatively simple:
+
+1. Collect config files from your players.
+2. Create a zip file containing your players' config files.
+3. Upload that zip file to the Generate page above.
+    - Generate page: [WebHost Seed Generation Page](/generate)
+4. Wait a moment while the seed is generated.
+5. When the seed is generated, you will be redirected to a "Seed Info" page.
+6. Click "Create New Room". This will take you to the server page. Provide the link to this page to your players, so
+   they may download their patch files from there.
+7. Note that a link to a MultiWorld Tracker is at the top of the room page. The tracker shows the progress of all
+   players in the game. Any observers may also be given the link to this page.
+8. Once all players have joined, you may begin playing.

--- a/worlds/pharcryption/docs/en_Pharcryption.md
+++ b/worlds/pharcryption/docs/en_Pharcryption.md
@@ -1,0 +1,34 @@
+# Pharcryption
+
+## What is Pharcryption? 
+
+TBA
+
+## Game Progression
+
+TBA
+
+## Key Items
+
+TBA
+
+## Reward Placement
+
+TBA
+
+## Trapped Chests
+
+TBA
+
+
+## Other information
+
+TBA
+
+## Where is the settings page?
+
+TBA
+
+## When does a player receive items?
+
+TBA

--- a/worlds/pharcryption/docs/setup_en.md
+++ b/worlds/pharcryption/docs/setup_en.md
@@ -1,0 +1,22 @@
+# Pharcryption Setup Guide
+
+### How to play:
+
+TBA
+
+
+## Hosting a MultiWorld game
+
+The recommended way to host a game is to use our hosting service. The process is relatively simple:
+
+1. Collect config files from your players.
+2. Create a zip file containing your players' config files.
+3. Upload that zip file to the Generate page above.
+    - Generate page: [WebHost Seed Generation Page](/generate)
+4. Wait a moment while the seed is generated.
+5. When the seed is generated, you will be redirected to a "Seed Info" page.
+6. Click "Create New Room". This will take you to the server page. Provide the link to this page to your players, so
+   they may download their patch files from there.
+7. Note that a link to a MultiWorld Tracker is at the top of the room page. The tracker shows the progress of all
+   players in the game. Any observers may also be given the link to this page.
+8. Once all players have joined, you may begin playing.

--- a/worlds/plateup/docs/en_PlateUp.md
+++ b/worlds/plateup/docs/en_PlateUp.md
@@ -1,0 +1,34 @@
+# PlateUp!
+
+## What is PlateUp!? 
+
+TBA
+
+## Game Progression
+
+TBA
+
+## Key Items
+
+TBA
+
+## Reward Placement
+
+TBA
+
+## Trapped Chests
+
+TBA
+
+
+## Other information
+
+TBA
+
+## Where is the settings page?
+
+TBA
+
+## When does a player receive items?
+
+TBA

--- a/worlds/plateup/docs/setup_en.md
+++ b/worlds/plateup/docs/setup_en.md
@@ -1,0 +1,22 @@
+# PlateUp! Setup Guide
+
+### How to play:
+
+TBA
+
+
+## Hosting a MultiWorld game
+
+The recommended way to host a game is to use our hosting service. The process is relatively simple:
+
+1. Collect config files from your players.
+2. Create a zip file containing your players' config files.
+3. Upload that zip file to the Generate page above.
+    - Generate page: [WebHost Seed Generation Page](/generate)
+4. Wait a moment while the seed is generated.
+5. When the seed is generated, you will be redirected to a "Seed Info" page.
+6. Click "Create New Room". This will take you to the server page. Provide the link to this page to your players, so
+   they may download their patch files from there.
+7. Note that a link to a MultiWorld Tracker is at the top of the room page. The tracker shows the progress of all
+   players in the game. Any observers may also be given the link to this page.
+8. Once all players have joined, you may begin playing.


### PR DESCRIPTION
Fixed a bug where the Tutorials attribute of a webworld would crash the webhost
Custom worlds that did not initialize this attribute would break, so defaulted the list in the webworld to account for this
Added placeholder docs for a few worlds that somehow flew under the radar until the new tutorial update
Updated the /tutorials/ route to just be /tutorials as navigation to the landing page for tutorials was still broken