### PR TITLE
Fix ladx client --no-magpie command line option

### DIFF
--- a/worlds/ladx_beta/LinksAwakeningClient.py
+++ b/worlds/ladx_beta/LinksAwakeningClient.py
@@ -423,7 +423,8 @@ class LinksAwakeningClient():
         self.tracker = LocationTracker(self.gameboy)
         self.item_tracker = ItemTracker(self.gameboy)
         self.gps_tracker = GpsTracker(self.gameboy)
-        magpie.gps_tracker = self.gps_tracker
+        if magpie != None:
+            magpie.gps_tracker = self.gps_tracker
 
     # The key location is blocked from collection unless the value location
     # has also been checked.


### PR DESCRIPTION
This PR fix the --no-magpie command line option which did not work anymore since the rework.
I tested it with a few checks and it seemed to work well.

It should fix #83.

